### PR TITLE
fix musl-libc for 227.2/227.3: do not change stderr/stdout variables.

### DIFF
--- a/src/shared/pager.c
+++ b/src/shared/pager.c
@@ -150,8 +150,13 @@ void pager_close(void) {
                 return;
 
         /* Inform pager that we are done */
+#if defined(__GLIBC__)
         stdout = safe_fclose(stdout);
         stderr = safe_fclose(stderr);
+#else
+        (void) safe_fclose(stdout);
+        (void) safe_fclose(stderr);
+#endif // in musl-libc these are const
 
         (void) kill(pager_pid, SIGCONT);
         (void) wait_for_terminate(pager_pid, NULL);


### PR DESCRIPTION
musl marks those variables as readonly and therefore fails while building at this file:

```
  CC       src/shared/libshared_la-spawn-polkit-agent.lo
src/shared/pager.c: In function 'pager_close':
src/shared/pager.c:153:16: error: assignment of read-only variable 'stdout'
         stdout = safe_fclose(stdout);
                ^
src/shared/pager.c:154:16: error: assignment of read-only variable 'stderr'
         stderr = safe_fclose(stderr);
                ^
make[2]: *** [Makefile:2814: src/shared/libshared_la-pager.lo] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [Makefile:3368: all-recursive] Error 1
make: *** [Makefile:1535: all] Error 2
```