### PR TITLE
228.1: fix musl

### DIFF
--- a/src/basic/log.c
+++ b/src/basic/log.c
@@ -21,7 +21,11 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#ifdef __GLIBC__
 #include <printf.h>
+#else
+#include "parse-printf-format.h"
+#endif
 #include <stdarg.h>
 #include <stddef.h>
 #include <stdio.h>

--- a/src/basic/stdio-util.h
+++ b/src/basic/stdio-util.h
@@ -21,7 +21,9 @@
   along with systemd; If not, see <http://www.gnu.org/licenses/>.
 ***/
 
+#ifdef __GLIBC__
 #include <printf.h>
+#endif
 #include <stdarg.h>
 #include <stdio.h>
 #include <sys/types.h>


### PR DESCRIPTION
This patch fix the musl libc builds at VoidLinux. Comes from 228.1, but applies to master too.