### PR TITLE
musl-fix for 228.3

### DIFF
--- a/src/basic/fs-util.h
+++ b/src/basic/fs-util.h
@@ -51,7 +51,12 @@ int fchmod_umask(int fd, mode_t mode);
 
 int fd_warn_permissions(const char *path, int fd);
 
+#ifdef __GLIBC__
 #define laccess(path, mode) faccessat(AT_FDCWD, (path), (mode), AT_SYMLINK_NOFOLLOW)
+#else
+#define laccess(path, mode) faccessat(AT_FDCWD, (path), (mode), 0)
+#endif
+
 
 int touch_file(const char *path, bool parents, usec_t stamp, uid_t uid, gid_t gid, mode_t mode);
 int touch(const char *path);


### PR DESCRIPTION
faccessat does not support AT_SYMLINK_NOFOLLOW with musl.