### PR TITLE
Update test-login.c

### DIFF
--- a/src/libelogind/sd-login/test-login.c
+++ b/src/libelogind/sd-login/test-login.c
@@ -61,7 +61,7 @@ static void test_login(void) {
         uid_t u, u2;
         char *t, **seats, **sessions;
 
-#if 0 // elogind does not support systemd slices
+#if 0 /// elogind does not support systemd slices
         r = sd_pid_get_unit(0, &unit);
         assert_se(r >= 0 || r == -ENODATA);
         log_info("sd_pid_get_unit(0, …) → \"%s\"", strna(unit));
@@ -73,7 +73,7 @@ static void test_login(void) {
         r = sd_pid_get_slice(0, &slice);
         assert_se(r >= 0 || r == -ENODATA);
         log_info("sd_pid_get_slice(0, …) → \"%s\"", strna(slice));
-#endif
+#endif // 0
 
         r = sd_pid_get_session(0, &session);
         if (r < 0) {

--- a/src/libelogind/sd-login/test-login.c
+++ b/src/libelogind/sd-login/test-login.c
@@ -61,6 +61,7 @@ static void test_login(void) {
         uid_t u, u2;
         char *t, **seats, **sessions;
 
+#if 0 // elogind does not support systemd slices
         r = sd_pid_get_unit(0, &unit);
         assert_se(r >= 0 || r == -ENODATA);
         log_info("sd_pid_get_unit(0, …) → \"%s\"", strna(unit));
@@ -72,6 +73,7 @@ static void test_login(void) {
         r = sd_pid_get_slice(0, &slice);
         assert_se(r >= 0 || r == -ENODATA);
         log_info("sd_pid_get_slice(0, …) → \"%s\"", strna(slice));
+#endif
 
         r = sd_pid_get_session(0, &session);
         if (r < 0) {
@@ -304,3 +306,4 @@ int main(int argc, char* argv[]) {
 
         return 0;
 }
+


### PR DESCRIPTION
I've ran the tests and noticed test-login.c failed, because elogind does not support systemd slices. This patch is intended to fix that.