### PR TITLE
Comment out unsupported eudev builtin "uaccess"

### DIFF
--- a/src/login/73-seat-late.rules.in
+++ b/src/login/73-seat-late.rules.in
@@ -12,6 +12,9 @@ ENV{ID_SEAT}=="", IMPORT{parent}="ID_SEAT"
 
 ENV{ID_SEAT}!="", TAG+="$env{ID_SEAT}"
 
-TAG=="uaccess", ENV{MAJOR}!="", RUN{builtin}+="uaccess"
+# "uaccess" builtin is not supported by eudev because "uaccess" uses
+# logind to get currently logged in user. (thus systemd-udev depends on
+# systemd-logind)
+#TAG=="uaccess", ENV{MAJOR}!="", RUN{builtin}+="uaccess"
 
 LABEL="seat_late_end"


### PR DESCRIPTION
I came accross this when packaing elogind for Devuan. eudev does not support the "uaccess" builtin. This fans out a warning by udev on boot. This rule requires an access from eudev to elogind. (eudev queries the currently active user) This builtin was removed from eudev and I think this will not come back in future.