### PR TITLE
Fixes for musl libc.

### DIFF
--- a/src/basic/process-util.c
+++ b/src/basic/process-util.c
@@ -1022,8 +1022,10 @@ static void reset_cached_pid(void) {
 /* We use glibc __register_atfork() + __dso_handle directly here, as they are not included in the glibc
  * headers. __register_atfork() is mostly equivalent to pthread_atfork(), but doesn't require us to link against
  * libpthread, as it is part of glibc anyway. */
+#ifdef __GLIBC__
 extern int __register_atfork(void (*prepare) (void), void (*parent) (void), void (*child) (void), void * __dso_handle);
 extern void* __dso_handle __attribute__ ((__weak__));
+#endif // ifdef __GLIBC__
 
 pid_t getpid_cached(void) {
         pid_t current_value;

--- a/src/shared/musl_missing.h
+++ b/src/shared/musl_missing.h
@@ -24,6 +24,7 @@ void elogind_set_program_name(const char* pcall);
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <pthread.h> /* for pthread_atfork */
 
 #define strerror_r(e, m, k) (strerror_r(e, m, k) < 0 ? strdup("strerror_r() failed") : m);
 
@@ -98,6 +99,13 @@ typedef __compar_fn_t comparison_fn_t;
 #   define _PATH_WTMPX _PATH_WTMP
 # endif
 #endif // ENABLE_UTMP
+
+/*
+ * Systemd makes use of undeclared glibc-specific __register_atfork to avoid
+ * a depednency on libpthread, __register_atfork is roughly equivalent to
+ * pthread_atfork so define __register_atfork to pthread_atfork.
+ */
+#define __register_atfork(prepare,parent,child,dso) pthread_atfork(prepare,parent,child)
 
 #endif // !defined(__GLIBC__)
 

--- a/src/shared/musl_missing.h
+++ b/src/shared/musl_missing.h
@@ -86,7 +86,7 @@ typedef __compar_fn_t comparison_fn_t;
 #endif
 
 /* Make musl utmp/wtmp stubs visible if needed. */
-#ifdef HAVE_UTMP
+#if ENABLE_UTMP
 # include <paths.h>
 # include <utmp.h>
 # include <utmpx.h>
@@ -96,7 +96,7 @@ typedef __compar_fn_t comparison_fn_t;
 # if defined(_PATH_WTMP) && !defined(_PATH_WTMPX)
 #   define _PATH_WTMPX _PATH_WTMP
 # endif
-#endif // HAVE_UTMP
+#endif // ENABLE_UTMP
 
 #endif // !defined(__GLIBC__)
 

--- a/src/shared/musl_missing.h
+++ b/src/shared/musl_missing.h
@@ -41,9 +41,10 @@ extern char *program_invocation_short_name;
  * + test if the effective capability bit was set on the executable file
  * + test if the process has a nonempty permitted capability set
  */
-#if !defined(HAVE_SECURE_GETENV) && !defined(HAVE___SECURE_GETENV)
+#if ! HAVE_SECURE_GETENV && ! HAVE___SECURE_GETENV
 #  define secure_getenv(name) \
         (issetugid() ? NULL : getenv(name))
+#  undef HAVE_SECURE_GETENV
 #  define HAVE_SECURE_GETENV 1
 #endif // HAVE_[__]SECURE_GETENV
 

--- a/src/test/test-sizeof.c
+++ b/src/test/test-sizeof.c
@@ -48,8 +48,10 @@ int main(void) {
         info(unsigned);
         info(long unsigned);
         info(long long unsigned);
+#ifdef __GLIBC__
         info(__syscall_ulong_t);
         info(__syscall_slong_t);
+#endif // ifdef __GLIBC__
 
         info(float);
         info(double);
@@ -59,7 +61,9 @@ int main(void) {
         info(ssize_t);
         info(time_t);
         info(usec_t);
+#ifdef __GLIBC__
         info(__time_t);
+#endif // ifdef __GLIBC__
         info(pid_t);
         info(gid_t);
 


### PR DESCRIPTION
- src/shared/musl_missing.h: mostly adaptation to new meson build system and defining __register_atfork to pthread_atfork due to the lack of the former on musl systems.
- src/test/test-sizeof.c has typedefs not available on musl guarded against them.
- src/basic/process-util.c has the definition of __register_atfork guarded to be used only on glibc systems

More info in each commit.