### PR TITLE
Fix proper daemonizing with sysvinit/startpar

### DIFF
--- a/src/login/elogind.c
+++ b/src/login/elogind.c
@@ -125,6 +125,12 @@ static int elogind_daemonize(void) {
 
         /* The first child has to become a new session leader. */
         close_all_fds(NULL, 0);
+
+        /* close_all_fds() does not close 0,1,2 */
+        close(0);
+        close(1);
+        close(2);
+
         SID = setsid();
         if ((pid_t)-1 == SID)
                 return log_error_errno(errno, "Failed to create new SID: %m");


### PR DESCRIPTION
While testing for devuan i came accross an issue with daemonizing. Devuan's sysvinit uses "startpar" to implement parallel startup of services. After the system has booted there was still a running instance of "startpar" waiting for elogind, although elogind was already running as service. 
I found that this problem can be solved by explicitly closing stdin/stdout/stderr file descriptors. Not sure if my solution is optimal or correct.