### PR TITLE
Fix build on musl

### DIFF
--- a/src/shared/musl_missing.h
+++ b/src/shared/musl_missing.h
@@ -20,7 +20,6 @@
 void elogind_set_program_name(const char* pcall);
 
 #if !defined(__GLIBC__)
-#include "config.h"
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>


### PR DESCRIPTION
Before this fix, elogind did not compile on musl, as the header "musl-missing.h" tries to include a nonexistant header: "config.h". This patch fixes that. Musl compiles with no issues once this patch is administered.