### PR TITLE
musl_missing.h: add FTW_* macros missing for musl libc.

### DIFF
--- a/src/shared/musl_missing.h
+++ b/src/shared/musl_missing.h
@@ -107,6 +107,27 @@ typedef __compar_fn_t comparison_fn_t;
  */
 #define __register_atfork(prepare,parent,child,dso) pthread_atfork(prepare,parent,child)
 
+/* 
+ * Missing FTW macros in musl, define them if not defined
+ * taken from
+ * https://git.yoctoproject.org/cgit.cgi/poky/plain/meta/recipes-core/systemd/systemd/0028-add-missing-FTW_-macros-for-musl.patch
+ */
+#ifndef FTW_ACTIONRETVAL
+#define FTW_ACTIONRETVAL 16
+#endif
+
+#ifndef FTW_CONTINUE
+#define FTW_CONTINUE 0
+#endif
+
+#ifndef FTW_STOP
+#define FTW_STOP 1
+#endif
+
+#ifndef FTW_SKIP_SUBTREE
+#define FTW_SKIP_SUBTREE 2
+#endif
+
 #endif // !defined(__GLIBC__)
 
 #endif // ELOGIND_BASIC_MUSL_MISSING_H_INCLUDED


### PR DESCRIPTION
i have come again.

This adds missing macros for FTW_* stuff used on src/basic/locale-util.c  src/core/mount-setup.c .

it is untested as i don't own a *-musl system but it compiles on aarch64-musl. 

i still need to run the tests.