### PR TITLE
Create elogind-inhibit.xml

### DIFF
--- a/man/elogind-inhibit.xml
+++ b/man/elogind-inhibit.xml
@@ -1,0 +1,157 @@
+<?xml version='1.0'?> <!--*-nxml-*-->
+<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.2//EN"
+  "http://www.oasis-open.org/docbook/xml/4.2/docbookx.dtd">
+
+<!--
+  SPDX-License-Identifier: LGPL-2.1+
+-->
+
+<refentry id="elogind-inhibit"
+    xmlns:xi="http://www.w3.org/2001/XInclude">
+
+  <refentryinfo>
+    <title>elogind-inhibit</title>
+    <productname>elogind</productname>
+  </refentryinfo>
+
+  <refmeta>
+    <refentrytitle>elogind-inhibit</refentrytitle>
+    <manvolnum>1</manvolnum>
+  </refmeta>
+
+  <refnamediv>
+    <refname>elogind-inhibit</refname>
+    <refpurpose>Execute a program with an inhibition lock taken</refpurpose>
+  </refnamediv>
+
+  <refsynopsisdiv>
+    <cmdsynopsis>
+      <command>elogind-inhibit <arg choice="opt" rep="repeat">OPTIONS</arg> <arg>COMMAND</arg> <arg choice="opt" rep="repeat">ARGUMENTS</arg></command>
+    </cmdsynopsis>
+    <cmdsynopsis>
+      <command>elogind-inhibit <arg choice="opt" rep="repeat">OPTIONS</arg> --list</command>
+    </cmdsynopsis>
+  </refsynopsisdiv>
+
+  <refsect1>
+    <title>Description</title>
+
+    <para><command>elogind-inhibit</command> may be used to execute a
+    program with a shutdown, sleep, or idle inhibitor lock taken. The
+    lock will be acquired before the specified command line is
+    executed and released afterwards.</para>
+
+    <para>Inhibitor locks may be used to block or delay system sleep
+    and shutdown requests from the user, as well as automatic idle
+    handling of the OS. This is useful to avoid system suspends while
+    an optical disc is being recorded, or similar operations that
+    should not be interrupted.</para>
+
+    <para>For more information see the <ulink
+    url="https://www.freedesktop.org/wiki/Software/systemd/inhibit">Inhibitor
+    Lock Developer Documentation</ulink>.</para>
+  </refsect1>
+
+  <refsect1>
+    <title>Options</title>
+
+    <para>The following options are understood:</para>
+
+    <variablelist>
+      <varlistentry>
+        <term><option>--what=</option></term>
+
+        <listitem><para>Takes a colon-separated list of one or more
+        operations to inhibit:
+        <literal>shutdown</literal>,
+        <literal>sleep</literal>,
+        <literal>idle</literal>,
+        <literal>handle-power-key</literal>,
+        <literal>handle-suspend-key</literal>,
+        <literal>handle-hibernate-key</literal>,
+        <literal>handle-lid-switch</literal>,
+        for inhibiting reboot/power-off/halt/kexec,
+        suspending/hibernating, the automatic idle detection, or the
+        low-level handling of the power/sleep key and the lid switch,
+        respectively. If omitted, defaults to
+        <literal>idle:sleep:shutdown</literal>.</para></listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><option>--who=</option></term>
+
+        <listitem><para>Takes a short, human-readable descriptive
+        string for the program taking the lock. If not passed,
+        defaults to the command line string.</para></listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><option>--why=</option></term>
+
+        <listitem><para>Takes a short, human-readable descriptive
+        string for the reason for taking the lock. Defaults to
+        "Unknown reason".</para></listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><option>--mode=</option></term>
+
+        <listitem><para>Takes either <literal>block</literal> or
+        <literal>delay</literal> and describes how the lock is
+        applied. If <literal>block</literal> is used (the default),
+        the lock prohibits any of the requested operations without
+        time limit, and only privileged users may override it. If
+        <literal>delay</literal> is used, the lock can only delay the
+        requested operations for a limited time. If the time elapses,
+        the lock is ignored and the operation executed. The time limit
+        may be specified in
+        <citerefentry><refentrytitle>logind.conf</refentrytitle><manvolnum>5</manvolnum></citerefentry>.
+        Note that <literal>delay</literal> is only available for
+        <literal>sleep</literal> and
+        <literal>shutdown</literal>.</para></listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><option>--list</option></term>
+
+        <listitem><para>Lists all active inhibition locks instead of
+        acquiring one.</para></listitem>
+      </varlistentry>
+
+      <xi:include href="standard-options.xml" xpointer="no-pager" />
+      <xi:include href="standard-options.xml" xpointer="no-legend" />
+      <xi:include href="standard-options.xml" xpointer="help" />
+      <xi:include href="standard-options.xml" xpointer="version" />
+    </variablelist>
+
+  </refsect1>
+
+  <refsect1>
+    <title>Exit status</title>
+
+    <para>Returns the exit status of the executed program.</para>
+  </refsect1>
+
+  <refsect1>
+    <title>Example</title>
+
+    <programlisting># elogind-inhibit wodim foobar.iso</programlisting>
+
+    <para>This burns the ISO image
+    <filename>foobar.iso</filename> on a CD using
+    <citerefentry project='man-pages'><refentrytitle>wodim</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
+    and inhibits system sleeping, shutdown and idle while
+    doing so.</para>
+  </refsect1>
+
+  <xi:include href="less-variables.xml" />
+
+  <refsect1>
+    <title>See Also</title>
+    <para>
+      <citerefentry><refentrytitle>elogind</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
+      <citerefentry><refentrytitle>logind.conf</refentrytitle><manvolnum>5</manvolnum></citerefentry>
+    </para>
+  </refsect1>
+
+</refentry>


### PR DESCRIPTION
Elogind is missing the man page for elogind-inhibit: this is just a copy of the systemd-inhibit manpage from systemd upstream, with 'systemd' replaced by 'elogind', where applicable.