### PR TITLE
printf: check for values of HAVE_PRINTF_H not if defined or not.

### DIFF
--- a/src/basic/parse-printf-format.c
+++ b/src/basic/parse-printf-format.c
@@ -25,7 +25,7 @@
 
 #include "parse-printf-format.h"
 
-#ifndef HAVE_PRINTF_H
+#if HAVE_PRINTF_H == 0
 
 static const char *consume_nonarg(const char *fmt)
 {

--- a/src/basic/parse-printf-format.h
+++ b/src/basic/parse-printf-format.h
@@ -24,7 +24,7 @@
 
 #include "config.h"
 
-#ifdef HAVE_PRINTF_H
+#if HAVE_PRINTF_H == 1
 #include <printf.h>
 #else
 


### PR DESCRIPTION
Meson works by setting 0 for not found and 1 for found, so check against
the value.