### PR TITLE
musl_missing.h: remove canonicalize_file_name

### DIFF
--- a/src/shared/musl_missing.h
+++ b/src/shared/musl_missing.h
@@ -64,10 +64,6 @@ extern char *program_invocation_short_name;
         } ) )
 #endif
 
-/* See http://man7.org/linux/man-pages/man3/canonicalize_file_name.3.html */
-#define canonicalize_file_name(path) \
-        realpath(path, NULL)
-
 /* GLOB_BRACE is another glibc extension - ignore it for musl libc */
 #define GLOB_BRACE 0
 


### PR DESCRIPTION
Not necessary anymore as all invocations of it are being replaced with
chase_symlink.