### PR TITLE
Fix cg_path_get_owner_uid

### DIFF
--- a/src/basic/cgroup-util.c
+++ b/src/basic/cgroup-util.c
@@ -20,6 +20,7 @@
 #include "cgroup-util.h"
 //#include "def.h"
 #include "dirent-util.h"
+#include "env-file.h"
 #include "extract-word.h"
 #include "fd-util.h"
 #include "fileio.h"
@@ -1844,7 +1845,7 @@ int cg_path_get_owner_uid(const char *path, uid_t *uid) {
 #else
         p = strappend("/run/systemd/sessions/", slice);
 
-        r = read_one_line_file(p, &s);
+        r = parse_env_file(NULL, p, "UID", &s);
         if (r == -ENOENT)
                 return -ENXIO;
         if (r < 0)


### PR DESCRIPTION
The session state is an env file, of which the first line is
```
 # This is private data. Do not parse.
```
so `read_one_line_file` won't return a value that can be parsed to a UID. Have updated to use `parse_env_file` to correctly read the UID. 

This fix is required due to a change introduced in gnome-session-3.34.2, as detailed here: https://gitlab.gnome.org/GNOME/gnome-session/issues/44