### PR TITLE
Look for reallocarray in stdlib.h as well

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -599,7 +599,8 @@ foreach ident : [
                                  #include <sys/stat.h>
                                  #include <unistd.h>'''],
         ['explicit_bzero' ,   '''#include <string.h>'''],
-        ['reallocarray',      '''#include <malloc.h>'''],
+        ['reallocarray',      '''#include <malloc.h>
+                                 #include <stdlib.h>'''],
         ['set_mempolicy',     '''#include <stdlib.h>
                                  #include <unistd.h>'''],
         ['get_mempolicy',     '''#include <stdlib.h>


### PR DESCRIPTION
musl [added support for reallocarray][0], but the function prototype is
declared in `stdlib.h` instead of `malloc.h`.

Update the check for reallocarray to check both in `malloc.h` and
`stdlib.h`.

[0]:https://git.musl-libc.org/cgit/musl/commit/?id=821083ac7b54eaa040d5a8ddc67c6206a175e0ca