### PR TITLE
logind: Fix org.freedesktop.login1.conf

### DIFF
--- a/src/login/org.freedesktop.login1.conf
+++ b/src/login/org.freedesktop.login1.conf
@@ -38,6 +38,12 @@
                        send_interface="org.freedesktop.DBus.Properties"
                        send_member="GetAll"/>
 
+                <!-- 1 /// Aditional action for elogind to reload its configuration -->
+                <allow send_destination="org.freedesktop.login1"
+                       send_interface="org.freedesktop.login1.Manager"
+                       send_member="ReloadConfig"/>
+                <!-- // 1 -->
+
                 <allow send_destination="org.freedesktop.login1"
                        send_interface="org.freedesktop.login1.Manager"
                        send_member="GetSession"/>
@@ -128,11 +134,6 @@
 
                 <allow send_destination="org.freedesktop.login1"
                        send_interface="org.freedesktop.login1.Manager"
-                <!-- 1 /// Aditional action for elogind to reload its configuration -->
-                <allow send_destination="org.freedesktop.login1"
-                       send_interface="org.freedesktop.login1.Manager"
-                       send_member="ReloadConfig"/>
-                <!-- // 1 -->
                        send_member="PowerOff"/>
 
                 <allow send_destination="org.freedesktop.login1"


### PR DESCRIPTION
commit a089dae138e1 "logind: add …WithFlags methods to policy" corrupted
org.freedesktop.login1.conf by "nesting" ReloadConfig inside PowerOff.
dbus throws a parsing error.  Fix the syntax by pulling ReloadConfig
out.  Also move it to the top of the file, at the beginning of the
Manager section, so this customization is more noticable instead of being
hidden in the middle.

dbus-daemon[722]: Encountered error 'Error in file /usr/share/dbus-1/system.d/org.freedesktop.login1.conf, line 131, column 16: not well-formed (invalid token)
' while parsing '/usr/share/dbus-1/system.d/org.freedesktop.login1.conf'

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>

I noticed this looking at the file.  This change doesn't make a difference in my limited setup.

I don't know that the practical implications of this patch are - Was nothing from the file allowed because it failed to parse?  Or was everything allowed?  Now the file should be honored properly, but people's setups may have relied on whatever DBus was doing before.