### PR TITLE
Patch for issue #224: exit on disconnect

### DIFF
--- a/src/login/logind.c
+++ b/src/login/logind.c
@@ -710,6 +710,13 @@ static int manager_connect_bus(Manager *m) {
         r = bus_call_method_async(m->bus, NULL, bus_systemd_mgr, "Subscribe", NULL, NULL, NULL);
         if (r < 0)
                 return log_error_errno(r, "Failed to enable subscription: %m");
+#else // 0
+        /* Since the facilities just above are not available, elogind needs another mean to
+         * take action when the dbus connection is closed.
+         */
+        r = sd_bus_set_exit_on_disconnect(m->bus, true);
+        if (r < 0)
+                return log_error_errno(r, "Failed to set exit on disconnect: %m");
 #endif // 0
 
         r = sd_bus_request_name_async(m->bus, NULL, "org.freedesktop.login1", 0, NULL, NULL);


### PR DESCRIPTION
When the dbus daemon is killed, elogind does not exit its main loop, so that it is not killed. After a subsequent restart of dbus, the elogind daemon cannot be started, to that the org.freedesktop.login1 name cannot be owned. Setting the exit_on_disconnect flag in the bus struct allows elogind to exit its main loop when dbus is killed.