### PR TITLE
loginctl: fix -P option parsing

### DIFF
--- a/src/login/loginctl.c
+++ b/src/login/loginctl.c
@@ -1454,9 +1454,9 @@ static int parse_argv(int argc, char *argv[]) {
         assert(argv);
 
 #if 0 /// elogind adds some system commands to loginctl
-        while ((c = getopt_long(argc, argv, "hp:P:als:H:M:n:o:", options, NULL)) >= 0)
+        while ((c = getopt_long(argc, argv, "hp:als:H:M:n:o:", options, NULL)) >= 0)
 #else // 0
-        while ((c = getopt_long(argc, argv, "hp:als:H:M:n:o:ci", options, NULL)) >= 0)
+        while ((c = getopt_long(argc, argv, "hp:P:als:H:M:n:o:ci", options, NULL)) >= 0)
 #endif // 0
 
                 switch (c) {


### PR DESCRIPTION
The -P option isn't recognized because it was added to getopt_long in the wrong place.