### PR TITLE
loginctl: remove useless --quiet option

### DIFF
--- a/src/login/eloginctl.c
+++ b/src/login/eloginctl.c
@@ -38,7 +38,6 @@
 elogind_action arg_action            = _ACTION_INVALID;
 bool           arg_ask_password      = true;
 bool           arg_dry_run           = false;
-bool           arg_quiet             = false;
 bool           arg_ignore_inhibitors = false;
 bool           arg_no_wall           = false;
 BusTransport   arg_transport         = BUS_TRANSPORT_LOCAL;
@@ -421,9 +420,6 @@ static int elogind_schedule_shutdown(sd_bus *bus, enum elogind_action a) {
                 return log_warning_errno(r,
                                 "Failed to call ScheduleShutdown in logind, proceeding with immediate shutdown: %s",
                                 bus_error_message(&error, r));
-
-        if (!arg_quiet)
-                log_info("Shutdown scheduled for %s, use 'shutdown -c' to cancel.", format_timestamp(date, sizeof(date), arg_when));
 
         return 0;
 }

--- a/src/login/loginctl.c
+++ b/src/login/loginctl.c
@@ -60,7 +60,6 @@ extern BusTransport arg_transport;
 static char *arg_host;
 extern bool arg_ask_password;
 extern bool arg_dry_run;
-extern bool arg_quiet;
 extern bool arg_no_wall;
 extern usec_t arg_when;
 extern bool arg_ignore_inhibitors;
@@ -1342,7 +1341,6 @@ static int help(int argc, char *argv[], void *userdata) {
 #if 1 /// elogind supports --no-wall and --dry-run
                "     --no-wall             Do not print any wall message\n"
                "     --dry-run             Only print what would be done\n"
-               "  -q --quiet               Suppress output\n"
 #endif // 1
                "     --no-legend           Do not show the headers and footers\n"
                "     --no-ask-password     Don't prompt for password\n"
@@ -1418,10 +1416,9 @@ static int parse_argv(int argc, char *argv[]) {
                 { "value",           no_argument,       NULL, ARG_VALUE           },
                 { "full",            no_argument,       NULL, 'l'                 },
                 { "no-pager",        no_argument,       NULL, ARG_NO_PAGER        },
-#if 1 /// elogind supports --no-wall, --dry-run and --quiet
+#if 1 /// elogind supports --no-wall and --dry-run
                 { "no-wall",         no_argument,       NULL, ARG_NO_WALL         },
                 { "dry-run",         no_argument,       NULL, ARG_DRY_RUN         },
-                { "quiet",           no_argument,       NULL, 'q'                 },
 #endif // 1
                 { "no-legend",       no_argument,       NULL, ARG_NO_LEGEND       },
                 { "kill-who",        required_argument, NULL, ARG_KILL_WHO        },
@@ -1517,7 +1514,7 @@ static int parse_argv(int argc, char *argv[]) {
                                 arg_legend = false;
 
                         break;
-#if 1 /// elogind supports --no-wall, -dry-run and --quiet
+#if 1 /// elogind supports --no-wall and --dry-run
                 case ARG_NO_WALL:
                         arg_no_wall = true;
                         break;
@@ -1525,10 +1522,6 @@ static int parse_argv(int argc, char *argv[]) {
                 case ARG_DRY_RUN:
                         arg_dry_run = true;
                         arg_pager_flags |= PAGER_DISABLE;
-                        break;
-
-                case 'q':
-                        arg_quiet = true;
                         break;
 #endif // 1
                 case ARG_NO_PAGER:


### PR DESCRIPTION
--quiet was ported from systemctl but only suppresses a single message in loginctl. Also, the short form -q is not recognized because it was never added to getopt_long.

Since this option barely works in the first place, I doubt anyone will miss it.