### PR TITLE
man/loginctl: document missing options

### DIFF
--- a/man/loginctl.xml
+++ b/man/loginctl.xml
@@ -526,7 +526,7 @@
 
       <!-- 1 /// elogind has a few options on its own. -->
       <varlistentry>
-        <term><option>-</option></term>
+        <term><option>-c</option></term>
 
         <listitem><para>Cancel a pending shutdown or reboot.</para></listitem>
       </varlistentry>

--- a/man/loginctl.xml
+++ b/man/loginctl.xml
@@ -545,6 +545,25 @@
           additional privileges.</para>
         </listitem>
       </varlistentry>
+
+      <varlistentry>
+        <term><option>--dry-run</option></term>
+
+        <listitem>
+          <para>Just print what would be done. Currently supported by verbs
+          <command>halt</command>, <command>poweroff</command>, <command>reboot</command>,
+          <command>suspend</command>, <command>hibernate</command>, <command>hybrid-sleep</command>,
+          and <command>suspend-then-hibernate</command>.</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><option>--no-wall</option></term>
+
+        <listitem>
+          <para>Do not send wall messages before halt, power-off and reboot.</para>
+        </listitem>
+      </varlistentry>
       <!-- // 1 -->
 
       <xi:include href="user-system-options.xml" xpointer="host" />


### PR DESCRIPTION
A couple options are missing from the man page. -c is documented but has a typo. I chose not to add --quiet because of #228.