### PR TITLE
musl_missing.h: re-add GNU basename macro for musl

### DIFF
--- a/src/basic/musl_missing.h
+++ b/src/basic/musl_missing.h
@@ -44,6 +44,10 @@ void elogind_set_program_name(const char* pcall);
 #  define HAVE_SECURE_GETENV 1
 #endif // HAVE_[__]SECURE_GETENV
 
+/* Poor man's basename */
+#define basename(path) \
+        (strrchr(path, '/') ? strrchr(path, '/')+1 : path)
+
 /* strndupa may already be defined in another compatibility header */
 #if !defined(strndupa)
 #define strndupa(x_src, x_n) \


### PR DESCRIPTION
This re-adds the GNU basename macro when compiling on musl.

Alternatively `#include <libgen.h>` can be added to `musl_missing.h`, this would continue the behavior as it currently is before the following musl change, although code will need to expect POSIX basename instead of GNU basename.

elgoind was able to build without either change on musl due to it containing a declaration in string.h (despite it only providing POSIX basename), this has recently been removed:
https://git.musl-libc.org/cgit/musl/commit/?id=725e17ed6dff4d0cd22487bb64470881e86a92e7

Let me know which way makes the most sense.