### PR TITLE
meson: fix handling of libexecdir option

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -150,7 +150,11 @@ localstatedir = get_option('localstatedir')
 localstatedir = localstatedir != '' ? localstatedir : '/var'
 
 libexecdir = get_option('libexecdir')
-libexecdir = libexecdir != '' ? libexecdir : prefixdir / 'lib/elogind'
+if libexecdir != '' and not fs.is_absolute(libexecdir)
+        libexecdir = prefixdir / libexecdir
+elif libexecdir == ''
+        libexecdir = prefixdir / 'lib/elogind'
+endif
 #endif // 0
 pkglibdir = libdir / 'elogind'
 


### PR DESCRIPTION
get_option('libexecdir') is designed to strip the prefix and return a relative directory if the top level directory is the same as what is set by --prefix. Handle this by appropriately joining directories if needed.

There might be other options in there that need handling like this, but this was the main one we encountered in Artix. You get `lib/elogind` otherwise.