### PR TITLE
Remove outdated musl hack in rlimit_nofile_safe

### DIFF
--- a/src/basic/rlimit-util.c
+++ b/src/basic/rlimit-util.c
@@ -428,11 +428,7 @@ int rlimit_nofile_safe(void) {
         rl.rlim_max = MIN(rl.rlim_max, (rlim_t) read_nr_open());
         rl.rlim_cur = MIN((rlim_t) FD_SETSIZE, rl.rlim_max);
         if (setrlimit(RLIMIT_NOFILE, &rl) < 0)
-#ifdef __GLIBC__ /// To be compatible with musl-libc, elogind uses an (uintmax_t) cast.
                 return log_debug_errno(errno, "Failed to lower RLIMIT_NOFILE's soft limit to " RLIM_FMT ": %m", rl.rlim_cur);
-#else // __GLIBC__
-                return log_debug_errno(errno, "Failed to lower RLIMIT_NOFILE's soft limit to " RLIM_FMT ": %m", (uintmax_t)rl.rlim_cur);
-#endif // __GLIBC__
 
         return 1;
 }


### PR DESCRIPTION
This was incorrect, because RLIM_FMT is not the format specifier for uintmax_t.

Since 53e84063a ("Change RLIM_FMT to '%llu' for non-glibc builds (#269)"), RLIM_FMT is correct for musl, so there's no longer any need for this casting version.