### PR TITLE
rlimit-util: Remove musl-specific uinitmax cast

### DIFF
--- a/src/basic/rlimit-util.c
+++ b/src/basic/rlimit-util.c
@@ -428,11 +428,7 @@ int rlimit_nofile_safe(void) {
         rl.rlim_max = MIN(rl.rlim_max, (rlim_t) read_nr_open());
         rl.rlim_cur = MIN((rlim_t) FD_SETSIZE, rl.rlim_max);
         if (setrlimit(RLIMIT_NOFILE, &rl) < 0)
-#ifdef __GLIBC__ /// To be compatible with musl-libc, elogind uses an (uintmax_t) cast.
                 return log_debug_errno(errno, "Failed to lower RLIMIT_NOFILE's soft limit to " RLIM_FMT ": %m", rl.rlim_cur);
-#else // __GLIBC__
-                return log_debug_errno(errno, "Failed to lower RLIMIT_NOFILE's soft limit to " RLIM_FMT ": %m", (uintmax_t)rl.rlim_cur);
-#endif // __GLIBC__
 
         return 1;
 }


### PR DESCRIPTION
rl.rlim_cur already has type 'long unsigned int', also on musl libc.

Otherwise build on musl fails with:

```
../src/basic/rlimit-util.c:417:47: error: format '%llu' expects argument of type 'long long unsigned int', but argument 7 has type 'long unsigned int' [-Werror=format=]
  417 |                 return log_debug_errno(errno, "Failed to lower RLIMIT_NOFILE's soft limit to " RLIM_FMT ": %m", (uintmax_t)rl.rlim_cur);
      |                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                  ~~~~~~~~~~~~~~~~~~~~~~
      |                                                                                                                 |
      |                                                                                                                 long unsigned int
```