### PR TITLE
Fix incorrect man page reference from sleep.conf(5) to logind.conf(5)

### DIFF
--- a/src/login/10-elogind.conf
+++ b/src/login/10-elogind.conf
@@ -9,7 +9,7 @@
 # Local configuration should be created here with a higher leading number so
 # they are parsed later overriding the defaults.
 #
-# See sleep.conf(5) for details.
+# See logind.conf(5) for details.
 
 [Login]
 # elogind is not a system manager, so it does not remove IPC-items by default


### PR DESCRIPTION
This pull request addresses [#300](https://github.com/elogind/elogind/issues/300).
The configuration file 10-elogind.conf includes a misleading comment:
```
# See sleep.conf(5) for details.
```
This reference is incorrect, as the file is related to ```elogind``` configuration, not ```sleep.conf```.

```
-# See sleep.conf(5) for details.
+# See logind.conf(5) for details.
```

This corrects the documentation to point users and developers to the appropriate manual page (logind.conf(5)), improving clarity and usability.