### PR TITLE
shared: Do not use malloc_info on musl

### DIFF
--- a/src/shared/common-signal.c
+++ b/src/shared/common-signal.c
@@ -65,12 +65,12 @@ int sigrtmin18_handler(sd_event_source *s, const struct signalfd_siginfo *si, vo
                         log_oom();
                         break;
                 }
-
+#ifdef __GLIBC__
                 if (malloc_info(0, f) < 0) {
                         log_error_errno(errno, "Failed to invoke malloc_info(): %m");
                         break;
                 }
-
+#endif
                 (void) memstream_dump(LOG_INFO, &m);
                 break;
         }


### PR DESCRIPTION
Fixes build on musl libc


Patch-Source: https://gitlab.postmarketos.org/postmarketOS/systemd/-/commit/4da194ac557283d80400fd3a4be63de0b5b7565c