### PR TITLE
sd-event: Make malloc_trim() conditional on glibc

### DIFF
--- a/src/libelogind/sd-event/sd-event.c
+++ b/src/libelogind/sd-event/sd-event.c
@@ -1881,7 +1881,7 @@ _public_ int sd_event_add_exit(
 }
 
 _public_ int sd_event_trim_memory(void) {
-        int r;
+        int r = 0;
 
         /* A default implementation of a memory pressure callback. Simply releases our own allocation caches
          * and glibc's. This is automatically used when people call sd_event_add_memory_pressure() with a
@@ -1895,7 +1895,9 @@ _public_ int sd_event_trim_memory(void) {
 
         usec_t before_timestamp = now(CLOCK_MONOTONIC);
         hashmap_trim_pools();
+#ifdef __GLIBC__
         r = malloc_trim(0);
+#endif
         usec_t after_timestamp = now(CLOCK_MONOTONIC);
 
         if (r > 0)


### PR DESCRIPTION
musl does not have this API

Fixes build on musl libc


Patch-Source: https://gitlab.postmarketos.org/postmarketOS/systemd/-/commit/591f6475b49cfd51baa9f329376a0bbf0dd991b5