### PR TITLE
Use sh instead of bash

### DIFF
--- a/src/basic/generate-cap-list.sh
+++ b/src/basic/generate-cap-list.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # SPDX-License-Identifier: LGPL-2.1-or-later
 set -eu
 set -o pipefail

--- a/src/basic/generate-errno-list.sh
+++ b/src/basic/generate-errno-list.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # SPDX-License-Identifier: LGPL-2.1-or-later
 set -eu
 set -o pipefail


### PR DESCRIPTION
Neither of these scripts require bash. Use `sh` instead, so downstream can avoid the additional dependency just for these.