### PR TITLE
rules: Add uaccess tag to /dev/udmabuf

### DIFF
--- a/rules.d/70-uaccess.rules.in
+++ b/rules.d/70-uaccess.rules.in
@@ -34,6 +34,8 @@ SUBSYSTEM=="sound", TAG+="uaccess", \
 SUBSYSTEM=="video4linux", TAG+="uaccess"
 SUBSYSTEM=="dvb", TAG+="uaccess"
 SUBSYSTEM=="media", TAG+="uaccess"
+# libcamera software ISP used with some cams requires udmabuf access
+KERNEL=="udmabuf", TAG+="uaccess"
 
 # industrial cameras, some webcams, camcorders, set-top boxes, TV sets, audio devices, and more
 SUBSYSTEM=="firewire", TEST=="units", ENV{IEEE1394_UNIT_FUNCTION_MIDI}=="1", TAG+="uaccess"


### PR DESCRIPTION
In some cases userspace may need to create dmabuffers from userspace on such example is the software ISP part of libcamera which needs to allocate dma-buffers for the output of the software ISP.

This is analoguous to what have been done in systemd, see: https://github.com/systemd/systemd/pull/33738/

More info: https://libcamera.org/faq.html#why-do-i-need-dma-heaps-or-udmabuf