### PR TITLE
Fix Build Errors with `glibc` v2.43 Under LLVM/Clang v21.x

### DIFF
--- a/src/basic/socket-util.c
+++ b/src/basic/socket-util.c
@@ -1724,13 +1724,13 @@ int socket_address_parse_vsock(SocketAddress *ret_address, const char *s) {
         assert(ret_address);
         assert(s);
 
-        if ((cid_start = startswith(s, "vsock:")))
+        if ((cid_start = (char*)startswith(s, "vsock:")))
                 type = 0;
-        else if ((cid_start = startswith(s, "vsock-dgram:")))
+        else if ((cid_start = (char*)startswith(s, "vsock-dgram:")))
                 type = SOCK_DGRAM;
-        else if ((cid_start = startswith(s, "vsock-seqpacket:")))
+        else if ((cid_start = (char*)startswith(s, "vsock-seqpacket:")))
                 type = SOCK_SEQPACKET;
-        else if ((cid_start = startswith(s, "vsock-stream:")))
+        else if ((cid_start = (char*)startswith(s, "vsock-stream:")))
                 type = SOCK_STREAM;
         else
                 return -EPROTO;

--- a/src/basic/string-util.c
+++ b/src/basic/string-util.c
@@ -1409,16 +1409,14 @@ char *strdupcspn(const char *a, const char *reject) {
         return strndup(a, strcspn(a, reject));
 }
 
-char *find_line_startswith(const char *haystack, const char *needle) {
-        char *p;
-
+char *find_line_startswith_internal(const char *haystack, const char *needle) {
         assert(haystack);
         assert(needle);
 
         /* Finds the first line in 'haystack' that starts with the specified string. Returns a pointer to the
          * first character after it */
 
-        p = strstr(haystack, needle);
+        char *p = (char*)strstr(haystack, needle);
         if (!p)
                 return NULL;
 
@@ -1436,7 +1434,7 @@ char *startswith_strv(const char *string, char **strv) {
         char *found = NULL;
 
         STRV_FOREACH(i, strv) {
-                found = startswith(string, *i);
+                found = (char*)startswith(string, *i);
                 if (found)
                         break;
         }

--- a/src/basic/string-util.h
+++ b/src/basic/string-util.h
@@ -26,23 +26,27 @@
 #define URI_UNRESERVED      ALPHANUMERICAL "-._~"       /* [RFC3986] */
 #define URI_VALID           URI_RESERVED URI_UNRESERVED /* [RFC3986] */
 
-static inline char* strstr_ptr(const char *haystack, const char *needle) {
+static inline char* strstr_ptr_internal(const char *haystack, const char *needle) {
         if (!haystack || !needle)
                 return NULL;
-        return strstr(haystack, needle);
+        return (char*)strstr(haystack, needle);
 }
 
-static inline char *strstrafter(const char *haystack, const char *needle) {
-        char *p;
+#define strstr_ptr(haystack, needle) \
+        const_generic(haystack, strstr_ptr_internal(haystack, needle))
 
+static inline char *strstrafter_internal(const char *haystack, const char *needle) {
         /* Returns NULL if not found, or pointer to first character after needle if found */
 
-        p = strstr_ptr(haystack, needle);
+        char *p = (char*)strstr_ptr(haystack, needle);
         if (!p)
                 return NULL;
 
         return p + strlen(needle);
 }
+
+#define strstrafter(haystack, needle) \
+        const_generic(haystack, strstrafter_internal(haystack, needle))
 
 static inline const char* strnull(const char *s) {
         return s ?: "(null)";
@@ -308,7 +312,9 @@ char *strdupspn(const char *a, const char *accept);
 #endif // 0
 char *strdupcspn(const char *a, const char *reject);
 
-char *find_line_startswith(const char *haystack, const char *needle);
+char* find_line_startswith_internal(const char *haystack, const char *needle);
+#define find_line_startswith(haystack, needle) \
+        const_generic(haystack, find_line_startswith_internal(haystack, needle))
 
 char *startswith_strv(const char *string, char **strv);
 

--- a/src/basic/strv.h
+++ b/src/basic/strv.h
@@ -229,7 +229,7 @@ static inline void strv_print(char * const *l) {
                 const char *_p = (p);                           \
                 char *_found = NULL;                            \
                 STRV_FOREACH(_i, STRV_MAKE(__VA_ARGS__)) {      \
-                        _found = endswith(_p, *_i);             \
+                        _found = (char*)endswith(_p, *_i);      \
                         if (_found)                             \
                                 break;                          \
                 }                                               \

--- a/src/basic/time-util.c
+++ b/src/basic/time-util.c
@@ -1140,7 +1140,7 @@ static const char* extract_multiplier(const char *p, usec_t *ret) {
         for (size_t i = 0; i < ELEMENTSOF(table); i++) {
                 char *e;
 
-                e = startswith(p, table[i].suffix);
+                e = (char*)startswith(p, table[i].suffix);
                 if (e) {
                         *ret = table[i].usec;
                         return e;

--- a/src/basic/unit-name.c
+++ b/src/basic/unit-name.c
@@ -845,7 +845,7 @@ int slice_build_subslice(const char *slice, const char *name, char **ret) {
         else {
                 char *e;
 
-                assert_se(e = endswith(slice, ".slice"));
+                assert_se(e = (char*)endswith(slice, ".slice"));
 
                 subslice = new(char, (e - slice) + 1 + strlen(name) + 6 + 1);
                 if (!subslice)

--- a/src/fundamental/macro-fundamental.h
+++ b/src/fundamental/macro-fundamental.h
@@ -518,3 +518,10 @@ static inline uint64_t ALIGN_OFFSET_U64(uint64_t l, uint64_t ali) {
 #else
         #define DECLARE_SBAT(text)
 #endif
+
+/* This macro is used to have a const-returning and non-const returning version of a function based on
+ * whether its first argument is const or not (e.g. strstr()). */
+#define const_generic(ptr, call)                              \
+        _Generic(0 ? (ptr) : (void*) 1,                       \
+                 const void*: (const typeof(*call)*) (call),  \
+                 void*: (call))

--- a/src/fundamental/string-util-fundamental.c
+++ b/src/fundamental/string-util-fundamental.c
@@ -7,7 +7,7 @@
 #include "macro-fundamental.h"
 #include "string-util-fundamental.h"
 
-sd_char *startswith(const sd_char *s, const sd_char *prefix) {
+sd_char *startswith_internal(const sd_char *s, const sd_char *prefix) {
         size_t l;
 
         assert(s);
@@ -20,7 +20,7 @@ sd_char *startswith(const sd_char *s, const sd_char *prefix) {
         return (sd_char*) s + l;
 }
 
-sd_char *startswith_no_case(const sd_char *s, const sd_char *prefix) {
+sd_char *startswith_no_case_internal(const sd_char *s, const sd_char *prefix) {
         size_t l;
 
         assert(s);
@@ -33,7 +33,7 @@ sd_char *startswith_no_case(const sd_char *s, const sd_char *prefix) {
         return (sd_char*) s + l;
 }
 
-sd_char* endswith(const sd_char *s, const sd_char *postfix) {
+sd_char* endswith_internal(const sd_char *s, const sd_char *postfix) {
         size_t sl, pl;
 
         assert(s);
@@ -54,7 +54,7 @@ sd_char* endswith(const sd_char *s, const sd_char *postfix) {
         return (sd_char*) s + sl - pl;
 }
 
-sd_char* endswith_no_case(const sd_char *s, const sd_char *postfix) {
+sd_char* endswith_no_case_internal(const sd_char *s, const sd_char *postfix) {
         size_t sl, pl;
 
         assert(s);

--- a/src/fundamental/string-util-fundamental.h
+++ b/src/fundamental/string-util-fundamental.h
@@ -57,10 +57,17 @@ static inline size_t strlen_ptr(const sd_char *s) {
         return strlen(s);
 }
 
-sd_char *startswith(const sd_char *s, const sd_char *prefix) _pure_;
-sd_char *startswith_no_case(const sd_char *s, const sd_char *prefix) _pure_;
-sd_char *endswith(const sd_char *s, const sd_char *postfix) _pure_;
-sd_char *endswith_no_case(const sd_char *s, const sd_char *postfix) _pure_;
+sd_char *startswith_internal(const sd_char *s, const sd_char *prefix) _pure_;
+#define startswith(s, prefix) const_generic(s, startswith_internal(s, prefix))
+
+sd_char *startswith_no_case_internal(const sd_char *s, const sd_char *prefix) _pure_;
+#define startswith_no_case(s, prefix) const_generic(s, startswith_no_case_internal(s, prefix))
+
+sd_char *endswith_internal(const sd_char *s, const sd_char *suffix) _pure_;
+#define endswith(s, suffix) const_generic(s, endswith_internal(s, suffix))
+
+sd_char *endswith_no_case_internal(const sd_char *s, const sd_char *suffix) _pure_;
+#define endswith_no_case(s, suffix) const_generic(s, endswith_no_case_internal(s, suffix))
 
 static inline bool isempty(const sd_char *a) {
         return !a || a[0] == '\0';

--- a/src/libelogind/sd-bus/sd-bus.c
+++ b/src/libelogind/sd-bus/sd-bus.c
@@ -1416,14 +1416,14 @@ int bus_set_address_system_remote(sd_bus *b, const char *host) {
         if (*host == '[') {
                 char *t;
 
-                rbracket = strchr(host, ']');
+                rbracket = (char*)strchr(host, ']');
                 if (!rbracket)
                         return -EINVAL;
                 t = strndupa_safe(host + 1, rbracket - host - 1);
                 e = bus_address_escape(t);
                 if (!e)
                         return -ENOMEM;
-        } else if ((a = strchr(host, '@'))) {
+        } else if ((a = (char*)strchr(host, '@'))) {
                 if (*(a + 1) == '[') {
                         _cleanup_free_ char *t = NULL;
 
@@ -1443,7 +1443,7 @@ int bus_set_address_system_remote(sd_bus *b, const char *host) {
         }
 
         /* Let's see if a port was given */
-        m = strchr(rbracket ? rbracket + 1 : host, ':');
+        m = (char*)strchr(rbracket ? rbracket + 1 : host, ':');
         if (m) {
                 char *t;
                 bool got_forward_slash = false;
@@ -1466,7 +1466,7 @@ int bus_set_address_system_remote(sd_bus *b, const char *host) {
         }
 
         /* Let's see if a machine was given */
-        m = strchr(rbracket ? rbracket + 1 : host, '/');
+        m = (char*)strchr(rbracket ? rbracket + 1 : host, '/');
         if (m) {
                 m++;
 interpret_port_as_machine_old_syntax:


### PR DESCRIPTION
 - LLVM/Clang v21.x enables '`-Werror,-Wincompatible-pointer-types- discards-qualifiers`' by default.  
 - '`glibc`' v2.43 adds stricter '`const`'-qualification of certain string-manipulation utility functions by adding versions of them that take '`const`' values as arguments and return '`const`' values.  

Fix this by:  

 - Borrowing/stealing something like `glibc`'s '`const`'-ness–agnostic function definition trick where needed.  
 - Adding any other necessary type casts.  

('`const`-ness really shouldn't be cast away, but this gets the project to build.)  

See commit messages and contents for details.  

Additionally, this is also partly a backport of upstream `systemd` commit '[`0bac1ed`](https://github.com/systemd/systemd/commit/0bac1ed2422f15308414dd1e9d09812a966b0348).'  

I've created this PR as a draft to start off with since I'm not entirely sure it's perfect/fully baked yet; comments are welcome.  

Closes #337.  