### PR TITLE
login: fix NULL pointer dereference in elogind_execute_shutdown_or_sleep()

### DIFF
--- a/src/login/logind-dbus.c
+++ b/src/login/logind-dbus.c
@@ -2110,7 +2110,7 @@ static int elogind_execute_shutdown_or_sleep(
 
         log_debug_elogind("Exiting from %s", program_invocation_short_name);
 
-        log_info("Operation '%s' finished.", handle_action_to_string(m->delayed_action->handle));
+        log_info("Operation '%s' finished.", handle_action_to_string(a->handle));
 
         m->action_job = mfree(m->action_job);
         m->delayed_action = NULL;


### PR DESCRIPTION
`elogind_execute_shutdown_or_sleep()` dereferences `m->delayed_action->handle` in a `log_info()` call before `_exit()`. For immediate actions via `loginctl poweroff`/`reboot`, `m->delayed_action` is never set, causing a segfault in the forked child process.

The shutdown/reboot still succeeds since `elogind_shutdown_or_sleep()` has already completed, but it produces a kernel log entry on every shutdown/reboot:

```
e-poweroff[28374]: segfault at 0 ip 000055c1cf3073db sp 00007ffdba8783d0 error 4 in elogind[...]
```

The fix uses the function parameter `a` instead, which is already asserted non-NULL and used throughout the rest of the function.

Fixes #341