### PR TITLE
login: Continue watching leader pidfd after stop

### DIFF
--- a/src/login/logind-session.c
+++ b/src/login/logind-session.c
@@ -100,6 +100,8 @@ static int session_dispatch_leader_pidfd(sd_event_source *es, int fd, uint32_t r
 
         session_stop(s, /* force= */ false);
 
+        session_add_to_gc_queue(s);
+
         return 1;
 }
 
@@ -1362,6 +1364,8 @@ static int session_dispatch_fifo(sd_event_source *es, int fd, uint32_t revents, 
         log_debug_elogind("EOF on Session %s FIFO: Session died abnormally, stopping...", s->id);
         session_remove_fifo(s);
         session_stop(s, /* force = */ false);
+
+        session_add_to_gc_queue(s);
 
         return 1;
 }

--- a/src/login/logind-session.c
+++ b/src/login/logind-session.c
@@ -95,6 +95,9 @@ static int session_dispatch_leader_pidfd(sd_event_source *es, int fd, uint32_t r
         Session *s = ASSERT_PTR(userdata);
 
         assert(s->leader.fd == fd);
+
+        s->leader_pidfd_event_source = sd_event_source_unref(s->leader_pidfd_event_source);
+
         session_stop(s, /* force= */ false);
 
         return 1;
@@ -1037,7 +1040,6 @@ int session_stop(Session *s, bool force) {
                 return 0;
 
         s->timer_event_source = sd_event_source_unref(s->timer_event_source);
-        s->leader_pidfd_event_source = sd_event_source_unref(s->leader_pidfd_event_source);
 
         if (s->seat)
                 seat_evict_position(s->seat, s);


### PR DESCRIPTION
This ensures that garbage collection will be triggered when the leader process dies.

(cherry picked from commit b2a4109031c1bd79c498f8642df150deeebe1708)

[picked from systemd tree - fixes an issue wiht lightdm greeter sessions not terminating]