### PR TITLE
_nss_systemd_block and _nss_systemd_is_blocked cannot be static/inline

### DIFF
--- a/src/nss-elogind/nss-elogind.c
+++ b/src/nss-elogind/nss-elogind.c
@@ -1169,4 +1169,12 @@ enum nss_status _nss_systemd_getsgent_r(struct sgrp *result, char *buffer, size_
 enum nss_status _nss_systemd_initgroups_dyn(const char *user_name, gid_t gid, long *start, long *size, gid_t **groupsp, long int limit, int *errnop) {
         return _nss_elogind_initgroups_dyn(user_name, gid, start, size, groupsp, limit, errnop);
 }
+
+int _nss_systemd_block(bool b) {
+        return _nss_elogind_block(b);
+}
+
+bool _nss_systemd_is_blocked(void) {
+        return _nss_elogind_is_blocked();
+}
 #endif // 1

--- a/src/nss-elogind/nss-elogind.h
+++ b/src/nss-elogind/nss-elogind.h
@@ -13,5 +13,5 @@ static inline void _nss_elogind_unblockp(bool *b) {
 }
 
 /* aliases for using nss-elogind as a drop-in replacement for nss-systemd */
-static inline int  _nss_systemd_block(bool b)     { return _nss_elogind_block(b); }
-static inline bool _nss_systemd_is_blocked(void)  { return _nss_elogind_is_blocked(); }
+int _nss_systemd_block(bool b);
+bool _nss_systemd_is_blocked(void);


### PR DESCRIPTION
They need to be externally visible. They are referenced in the version script, but bfd ignores this anomaly. mold (without extra flags) treats this as a warning. lld always treats this as an error.

Bug: https://bugs.gentoo.org/974803