### PR TITLE
Fix elogind-257.14 no longer installs org.freedesktop.login1.service #354

### DIFF
--- a/src/login/meson.build
+++ b/src/login/meson.build
@@ -209,7 +209,8 @@ if enable_logind
                 output: 'org.freedesktop.login1.service',
                 command : [jinja2_cmdline, '@INPUT@', '@OUTPUT@'],
                 install: enable_logind,
-                install_dir : dbussystemservicedir)
+                install_dir : dbussystemservicedir,
+                install : true)
 #endif // 0
         install_data('org.freedesktop.login1.policy',
                      install_dir : polkitpolicydir)


### PR DESCRIPTION
Fix for elogind-257.14 no longer installs org.freedesktop.login1.service #354